### PR TITLE
Fix division deprecated

### DIFF
--- a/rhythm.sass
+++ b/rhythm.sass
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 // Support for power of
 @function pow($base, $exponent)
 	// reset value
@@ -9,7 +11,7 @@
 	// negitive intergers get divided. A number divided by itself is 1
 	@if $exponent < 1
 		@for $i from 0 through -$exponent
-			$value: $value / $base
+			$value: math.div($value, $base)
 	// return the last value written
 	@return ($value)
 
@@ -28,7 +30,7 @@ $base-line-height: $base-font-size * $line-height-scale
 
 		$local-font-scale: pow($font-scale, $font-size-multiplier)
 		$local-font-size: $base-font-size * $local-font-scale
-		$local-line-count: if($line-count, $line-count, ceil($local-font-size / $base-line-height))
+		$local-line-count: if($line-count, $line-count, ceil(math.div($local-font-size, $base-line-height)))
 		$local-line-height: $local-line-count * $base-line-height
 
 		@if $unit == "px" or $unit == "pxrem"
@@ -40,9 +42,9 @@ $base-line-height: $base-font-size * $line-height-scale
 				margin-bottom: $base-line-height * $margin-bottom-multiplier
 
 		@if $unit == "em"
-			$converted-line-height: ($base-line-height / $local-font-size) * 1em
-			font-size: ($local-font-size / $base-font-size) * 1em
-			line-height: ($local-line-height / $local-font-size) * 1em
+			$converted-line-height: math.div($base-line-height, $local-font-size) * 1em
+			font-size: math.div($local-font-size, $base-font-size) * 1em
+			line-height: math.div($local-line-height, $local-font-size) * 1em
 			@if $margin-top-multiplier > 0
 				margin-top: $converted-line-height * $margin-top-multiplier
 			@if $margin-bottom-multiplier > 0
@@ -50,9 +52,9 @@ $base-line-height: $base-font-size * $line-height-scale
 
 
 		@if $unit == "rem" or $unit == "pxrem"
-			$converted-line-height: ($base-line-height / $base-font-size) * 1rem
-			font-size: ($local-font-size / $base-font-size) * 1rem
-			line-height: ($local-line-height / $base-font-size) * 1rem
+			$converted-line-height: math.div($base-line-height, $base-font-size) * 1rem
+			font-size: math.div($local-font-size, $base-font-size) * 1rem
+			line-height: math.div($local-line-height, $base-font-size) * 1rem
 			@if $margin-top-multiplier > 0
 				margin-top: $converted-line-height * $margin-top-multiplier
 			@if $margin-bottom-multiplier > 0

--- a/rhythm.scss
+++ b/rhythm.scss
@@ -1,0 +1,87 @@
+@use "sass:math";
+
+// Support for power of
+@function pow($base, $exponent) {
+    // reset value
+    $value: $base;
+
+    // positive intergers get multiplied
+    @if $exponent>1 {
+        @for $i from 2 through $exponent {
+            $value: $value * $base;
+        }
+    }
+
+    // negitive intergers get divided. A number divided by itself is 1;
+    @if $exponent < 1 {
+        @for $i from 0 through -$exponent {
+            $value: math.div($value, $base);
+        }
+    }
+
+    // return the last value written;
+    @return ($value);
+
+    // Work out what the base line-height is in pixels
+}
+
+$base-line-height: $base-font-size * $line-height-scale;
+
+@mixin rhythm($font-size-multiplier, $margin-top-multiplier: 0, $margin-bottom-multiplier: 0, $line-count: null) {
+    @if $font-size-multiplier=="base" {
+        font-size: $base-font-size;
+        line-height: $base-line-height;
+    }
+
+    @else {
+        @if $true-scale {
+            $font-size-multiplier: if($font-size-multiplier <=1, 0, $font-size-multiplier - 1);
+        }
+
+        $local-font-scale: pow($font-scale, $font-size-multiplier);
+        $local-font-size: $base-font-size * $local-font-scale;
+        $local-line-count: if($line-count, $line-count, ceil(math.div($local-font-size, $base-line-height)));
+        $local-line-height: $local-line-count * $base-line-height;
+
+        @if $unit=="px"or $unit=="pxrem" {
+            font-size: $local-font-size;
+            line-height: $local-line-height;
+
+            @if $margin-top-multiplier>0 {
+                margin-top: $base-line-height * $margin-top-multiplier;
+            }
+
+            @if $margin-bottom-multiplier>0 {
+                margin-bottom: $base-line-height * $margin-bottom-multiplier;
+            }
+        }
+
+        @if $unit=="em" {
+            $converted-line-height: math.div($base-line-height, $local-font-size) * 1em;
+            font-size: math.div($local-font-size, $base-font-size) * 1em;
+            line-height: math.div($local-line-height, $local-font-size) * 1em;
+
+            @if $margin-top-multiplier>0 {
+                margin-top: $converted-line-height * $margin-top-multiplier;
+            }
+
+            @if $margin-bottom-multiplier>0 {
+                margin-bottom: $converted-line-height * $margin-bottom-multiplier;
+            }
+        }
+
+        @if $unit=="rem"or $unit=="pxrem" {
+            $converted-line-height: math.div($base-line-height, $base-font-size) * 1rem;
+            font-size: math.div($local-font-size, $base-font-size) * 1rem;
+            line-height: math.div($local-line-height, $base-font-size) * 1rem;
+
+            @if $margin-top-multiplier>0 {
+                margin-top: $converted-line-height * $margin-top-multiplier;
+            }
+
+            @if $margin-bottom-multiplier>0 {
+                margin-bottom: $converted-line-height * $margin-bottom-multiplier;
+            }
+        }
+    }
+}


### PR DESCRIPTION
1. fix the `Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.` error
2. Add scss version